### PR TITLE
+layout.svelte

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,12 @@
+<script>
+    import Header from '$lib/header.svelte';
+    import Footer from '$lib/footer.svelte';
+</script>
+
+<Header/>
+
+<main>
+    <slot/>
+</main>
+
+<Footer/>


### PR DESCRIPTION
### Beschrijving
De layout.svelte bestand is aangemaakt die de layout instelt voor elke pagina van de website.
De header en footer worden als componenten geïmport in het bestand zodat ze automatisch op elke pagina staan.
het bestand is in de routes folder geplaats zodat het toegepast wordt op elke pagina en niet specifieke bestanden.
In de main is de slot tag geplaatst en daar wordt de code ingeladen van alle andere pagina's.